### PR TITLE
Koyan can't tell a joke with single quote

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
           name: Get the joke
           command: |
             joke="$(./bin/joke.sh)"
-            echo "export JOKE_MSG='${joke}'" >> $BASH_ENV
-            echo "$joke"
+            echo "export JOKE_MSG=\"${joke}\"" >> $BASH_ENV
+            cat "$BASH_ENV"
       - slack/notify:
           channel: C014UMRC4AJ
           color: '#78c043'


### PR DESCRIPTION
Koyan (the bot, I don't know about the person) fails at telling jokes that include a single quote `'`.  
Replacing single quotes with escaped [double quotes](https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html) should do the trick.